### PR TITLE
Feature/mon 160365 2

### DIFF
--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -103,6 +103,8 @@ def renderView(request):
     else:
       cachedData = None
 
+    new_old_target_map = {}
+
     if cachedData is not None:
       requestContext['data'] = data = cachedData
     else: # Have to actually retrieve the data now
@@ -113,6 +115,12 @@ def renderView(request):
         seriesList = evaluateTarget(requestContext, target)
         log.rendering("Retrieval of %s took %.6f" % (target, time() - t))
         data.extend(seriesList)
+
+        if type(seriesList) is list:
+          if seriesList:
+            new_old_target_map[seriesList[0].name] = target
+        else:
+            new_old_target_map[seriesList.name] = target
 
       if useCache:
         cache.add(dataKey, data, cacheTimeout)
@@ -154,7 +162,7 @@ def renderView(request):
           else:
             timestamps = range(int(series.start), int(series.end) + 1, int(series.step))
           datapoints = zip(series, timestamps)
-          series_data.append(dict(target=series.name, datapoints=datapoints))
+          series_data.append(dict(target=series.name, datapoints=datapoints, input_target=new_old_target_map[series.name]))
       elif 'noNullPoints' in requestOptions and any(data):
         for series in data:
           values = []
@@ -163,12 +171,12 @@ def renderView(request):
               timestamp = series.start + (index * series.step)
               values.append((v,timestamp))
           if len(values) > 0:
-            series_data.append(dict(target=series.name, datapoints=values))
+            series_data.append(dict(target=series.name, datapoints=values, input_target=new_old_target_map[series.name]))
       else:
         for series in data:
           timestamps = range(int(series.start), int(series.end) + 1, int(series.step))
           datapoints = zip(series, timestamps)
-          series_data.append(dict(target=series.name, datapoints=datapoints))
+          series_data.append(dict(target=series.name, datapoints=datapoints, input_target=new_old_target_map[series.name]))
 
       if 'jsonp' in requestOptions:
         response = HttpResponse(
@@ -213,7 +221,7 @@ def renderView(request):
       for series in data:
         timestamps = range(series.start, series.end, series.step)
         datapoints = [{'x' : x, 'y' : y} for x, y in zip(timestamps, series)]
-        series_data.append( dict(target=series.name, datapoints=datapoints) )
+        series_data.append( dict(target=series.name, datapoints=datapoints, input_target=new_old_target_map[series.name]) )
       if 'jsonp' in requestOptions:
         response = HttpResponse(
           content="%s(%s)" % (requestOptions['jsonp'], json.dumps(series_data)),

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -251,6 +251,7 @@ class RenderTest(TestCase):
         })
         data = json.loads(response.content)[0]
         self.assertEqual(data['target'], 'nameOfSeries')
+        self.assertEqual(data['input_target'], 'template(time($1),"nameOfSeries")')
 
         url = reverse('graphite.render.views.renderView')
         response = self.client.get(url, {
@@ -261,6 +262,7 @@ class RenderTest(TestCase):
         })
         data = json.loads(response.content)[0]
         self.assertEqual(data['target'], 'nameOfSeries')
+        self.assertEqual(data['input_target'], 'template(time($name),name="nameOfSeries")')
 
         url = reverse('graphite.render.views.renderView')
         response = self.client.get(url, {
@@ -272,6 +274,21 @@ class RenderTest(TestCase):
         })
         data = json.loads(response.content)[0]
         self.assertEqual(data['target'], 'nameOfSeries')
+        self.assertEqual(data['input_target'], 'template(time($name))')
+
+
+    def test_render_input_target(self):
+        url = reverse('graphite.render.views.renderView')
+        response = self.client.get(url, {
+                 'target': 'constantLine(12)',
+                 'format': 'json',
+                 'from': '07:01_20140226',
+                 'until': '08:01_20140226',
+        })
+        data = json.loads(response.content)[0]
+        self.assertEqual(data['target'], '12')
+        self.assertEqual(data['input_target'], 'constantLine(12)')
+
 
     def test_template_pathExpression_variables(self):
         self.create_whisper_hosts()
@@ -284,6 +301,7 @@ class RenderTest(TestCase):
         })
         data = json.loads(response.content)[0]
         self.assertEqual(data['target'], 'sumSeries(hosts.worker1.cpu)')
+        self.assertEqual(data['input_target'], 'template(sumSeries(hosts.$1.cpu),"worker1")')
 
         response = self.client.get(url, {
                  'target': 'template(sumSeries(hosts.$1.cpu),"worker1")',
@@ -292,6 +310,7 @@ class RenderTest(TestCase):
         })
         data = json.loads(response.content)[0]
         self.assertEqual(data['target'], 'sumSeries(hosts.worker*.cpu)')
+        self.assertEqual(data['input_target'], 'template(sumSeries(hosts.$1.cpu),"worker1")')
 
         response = self.client.get(url, {
                  'target': 'template(sumSeries(hosts.$hostname.cpu))',
@@ -300,6 +319,7 @@ class RenderTest(TestCase):
         })
         data = json.loads(response.content)[0]
         self.assertEqual(data['target'], 'sumSeries(hosts.worker*.cpu)')
+        self.assertEqual(data['input_target'], 'template(sumSeries(hosts.$hostname.cpu))')
 
 class ConsistentHashRingTest(TestCase):
     def test_chr_compute_ring_position(self):


### PR DESCRIPTION
This PR is to fix this issue: #248. The "target" field in response sometimes does not show what was sent in target field in the request URL. This field is not making change in the "target" field (to maintain backwards compatibility) in response data but to add a new field "input_target" that reflects what's been sent as an input target. 