### PR TITLE
MO-919 fix for bug where a query that results in metrics with same na…

### DIFF
--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -168,7 +168,7 @@ def find_view(request):
     results = []
     found = set()
     for node in matches:
-      unique_key = "{name}|{is_leaf}".format(name=node.name, is_leaf=node.is_leaf)
+      unique_key = "{path}|{name}|{is_leaf}".format(path=node.path, name=node.name, is_leaf=node.is_leaf)
       if unique_key in found:
         continue
       found.add(unique_key)

--- a/webapp/tests/test_metrics.py
+++ b/webapp/tests/test_metrics.py
@@ -265,7 +265,6 @@ class MetricsTester(TestCase):
         content = self._find_view_basics(request)
         data = json.loads(content)
         data['metrics'] = sorted(data['metrics'])
-        #import pdb; pdb.set_trace()
         self.assertEqual(data, {u'metrics': [{u'name': u'*'}, {u'is_leaf': u'1', u'path': u'hosts.worker1.cpu', u'name': u'cpu'}, {u'is_leaf': u'1', u'path': u'hosts.worker2.cpu', u'name': u'cpu'}]})
 
         # Test from/until params
@@ -394,7 +393,6 @@ class MetricsTester(TestCase):
         request['query']='*'
         content = self._find_view_basics(request)
         data = json.loads(content.split("(")[1].strip(")"))
-        #import pdb; pdb.set_trace()
         self.assertEqual(data, [{u'path': u'hosts', u'is_leaf': False}])
 
         # leaf


### PR DESCRIPTION
…me but different paths is getting deduped.

The dedup logic is making a unique key using only name and is_leaf, it currently ignores path of a metric. This results in partial dataset to be returned to the client. Including path in the dedup key ensures that only dupes are removed and complete dataset is returned.